### PR TITLE
Change CI configuration not to run in parallel

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -3,6 +3,9 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    concurrency:
+      group: rspec_tests
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby 3.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Check `dependabot` at 8:00 Moscow time daily
 * Changes from `rubocop-rspec` update to 2.9.0
 * Fix `rubocop-1.28.1` code issues
+* Change CI configuration not to run in parallel (Fix [#500](https://github.com/ONLYOFFICE-QA/onlyoffice_bugzilla_helper/issues/500))
 
 ## 0.6.1 (2021-04-08)
 


### PR DESCRIPTION
Parallel runs can cause conflicts, because if we create two PR in same time - the results of run can conflict with each other

Fix #500 